### PR TITLE
Add fixed wing vehicle skeleton

### DIFF
--- a/AirLib/include/common/AirSimSettings.hpp
+++ b/AirLib/include/common/AirSimSettings.hpp
@@ -35,6 +35,7 @@ namespace airlib
         static constexpr char const* kVehicleTypePhysXCar = "physxcar";
         static constexpr char const* kVehicleTypeArduRover = "ardurover";
         static constexpr char const* kVehicleTypeComputerVision = "computervision";
+        static constexpr char const* kVehicleTypeFixedWing = "fixedwing";
 
         static constexpr char const* kVehicleInertialFrame = "VehicleInertialFrame";
         static constexpr char const* kSensorLocalFrame = "SensorLocalFrame";

--- a/AirLib/include/vehicles/fixedwing/FixedWingApiFactory.hpp
+++ b/AirLib/include/vehicles/fixedwing/FixedWingApiFactory.hpp
@@ -1,0 +1,22 @@
+#ifndef msr_airlib_vehicles_FixedWingApiFactory_hpp
+#define msr_airlib_vehicles_FixedWingApiFactory_hpp
+
+#include "FixedWingApiBase.hpp"
+
+namespace msr {
+namespace airlib {
+
+class FixedWingApiFactory
+{
+public:
+    static std::unique_ptr<FixedWingApiBase> createApi(const AirSimSettings::VehicleSetting* vehicle_setting,
+                                                       std::shared_ptr<SensorFactory> sensor_factory,
+                                                       const Kinematics::State& state, const Environment& environment)
+    {
+        return std::unique_ptr<FixedWingApiBase>(new FixedWingApiBase(vehicle_setting, sensor_factory, state, environment));
+    }
+};
+
+}} //namespace
+
+#endif

--- a/AirLib/include/vehicles/fixedwing/api/FixedWingApiBase.hpp
+++ b/AirLib/include/vehicles/fixedwing/api/FixedWingApiBase.hpp
@@ -1,0 +1,69 @@
+#ifndef msr_AirLib_FixedWingApiBase_hpp
+#define msr_AirLib_FixedWingApiBase_hpp
+
+#include "api/VehicleApiBase.hpp"
+#include "sensors/SensorCollection.hpp"
+#include "sensors/SensorFactory.hpp"
+
+namespace msr {
+namespace airlib {
+
+class FixedWingApiBase : public VehicleApiBase
+{
+public:
+    FixedWingApiBase(const AirSimSettings::VehicleSetting* vehicle_setting,
+                     std::shared_ptr<SensorFactory> sensor_factory,
+                     const Kinematics::State& state, const Environment& environment)
+    {
+        initialize(vehicle_setting, sensor_factory, state, environment);
+    }
+
+    virtual ~FixedWingApiBase() = default;
+
+    virtual void update() override
+    {
+        VehicleApiBase::update();
+        sensors_.update();
+    }
+
+    virtual const SensorCollection& getSensors() const override
+    {
+        return sensors_;
+    }
+
+    SensorCollection& getSensors()
+    {
+        return sensors_;
+    }
+
+    void initialize(const AirSimSettings::VehicleSetting* vehicle_setting,
+                    std::shared_ptr<SensorFactory> sensor_factory,
+                    const Kinematics::State& state, const Environment& environment)
+    {
+        sensor_factory_ = sensor_factory;
+        sensor_storage_.clear();
+        sensors_.clear();
+        addSensorsFromSettings(vehicle_setting);
+        sensors_.initialize(&state, &environment);
+    }
+
+    virtual void addSensorsFromSettings(const AirSimSettings::VehicleSetting* vehicle_setting)
+    {
+        const auto& sensor_settings = vehicle_setting->sensors;
+        sensor_factory_->createSensorsFromSettings(sensor_settings, sensors_, sensor_storage_);
+    }
+
+protected:
+    virtual void resetImplementation() override
+    {
+        sensors_.reset();
+    }
+
+    std::shared_ptr<const SensorFactory> sensor_factory_;
+    SensorCollection sensors_;
+    vector<shared_ptr<SensorBase>> sensor_storage_;
+};
+
+}} //namespace
+
+#endif

--- a/AirLib/include/vehicles/fixedwing/api/FixedWingRpcLibClient.hpp
+++ b/AirLib/include/vehicles/fixedwing/api/FixedWingRpcLibClient.hpp
@@ -1,0 +1,21 @@
+#ifndef msr_AirLib_FixedWingRpcLibClient_hpp
+#define msr_AirLib_FixedWingRpcLibClient_hpp
+
+#include "rpc/client.h"
+#include "vehicles/multirotor/api/MultirotorRpcLibClient.hpp"
+
+namespace msr {
+namespace airlib {
+
+class FixedWingRpcLibClient : public MultirotorRpcLibClient
+{
+public:
+    FixedWingRpcLibClient(const std::string& ip="", uint16_t port=41451, float timeout_sec=3600)
+        : MultirotorRpcLibClient(ip, port, timeout_sec)
+    {
+    }
+};
+
+}} //namespace
+
+#endif

--- a/AirLib/include/vehicles/fixedwing/api/FixedWingRpcLibServer.hpp
+++ b/AirLib/include/vehicles/fixedwing/api/FixedWingRpcLibServer.hpp
@@ -1,0 +1,20 @@
+#ifndef msr_AirLib_FixedWingRpcLibServer_hpp
+#define msr_AirLib_FixedWingRpcLibServer_hpp
+
+#include "vehicles/multirotor/api/MultirotorRpcLibServer.hpp"
+
+namespace msr {
+namespace airlib {
+
+class FixedWingRpcLibServer : public MultirotorRpcLibServer
+{
+public:
+    FixedWingRpcLibServer(ApiProvider* api_provider, const string& ip_address="", uint16_t port=41451)
+        : MultirotorRpcLibServer(api_provider, ip_address, port)
+    {
+    }
+};
+
+}} //namespace
+
+#endif

--- a/AirLib/src/vehicles/fixedwing/FixedWingApiFactory.cpp
+++ b/AirLib/src/vehicles/fixedwing/FixedWingApiFactory.cpp
@@ -1,0 +1,5 @@
+#include "vehicles/fixedwing/FixedWingApiFactory.hpp"
+
+using namespace msr::airlib;
+
+// No additional implementation needed yet

--- a/AirLib/src/vehicles/fixedwing/api/FixedWingRpcLibClient.cpp
+++ b/AirLib/src/vehicles/fixedwing/api/FixedWingRpcLibClient.cpp
@@ -1,0 +1,8 @@
+#include "vehicles/fixedwing/api/FixedWingRpcLibClient.hpp"
+
+using namespace msr::airlib;
+
+FixedWingRpcLibClient::FixedWingRpcLibClient(const std::string& ip, uint16_t port, float timeout_sec)
+    : MultirotorRpcLibClient(ip, port, timeout_sec)
+{
+}

--- a/AirLib/src/vehicles/fixedwing/api/FixedWingRpcLibServer.cpp
+++ b/AirLib/src/vehicles/fixedwing/api/FixedWingRpcLibServer.cpp
@@ -1,0 +1,8 @@
+#include "vehicles/fixedwing/api/FixedWingRpcLibServer.hpp"
+
+using namespace msr::airlib;
+
+FixedWingRpcLibServer::FixedWingRpcLibServer(ApiProvider* api_provider, const string& ip_address, uint16_t port)
+    : MultirotorRpcLibServer(api_provider, ip_address, port)
+{
+}

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -1646,3 +1646,15 @@ class CarClient(VehicleClient, object):
         """
         controls_raw = self.client.call('getCarControls', vehicle_name)
         return CarControls.from_msgpack(controls_raw)
+
+
+#----------------------------------- Fixed Wing APIs --------------------------------------
+class FixedWingClient(VehicleClient, object):
+    def __init__(self, ip = "", port = 41451, timeout_value = 3600):
+        super(FixedWingClient, self).__init__(ip, port, timeout_value)
+
+    def takeoffAsync(self, timeout_sec = 20, vehicle_name = ''):
+        return self.client.call_async('takeoff', timeout_sec, vehicle_name)
+
+    def landAsync(self, timeout_sec = 60, vehicle_name = ''):
+        return self.client.call_async('land', timeout_sec, vehicle_name)

--- a/PythonClient/fixedwing/hello_fixed_wing.py
+++ b/PythonClient/fixedwing/hello_fixed_wing.py
@@ -1,0 +1,18 @@
+import setup_path
+import airsim
+import pprint
+
+client = airsim.FixedWingClient()
+client.confirmConnection()
+client.enableApiControl(True)
+
+state = client.getMultirotorState()
+print("state: %s" % pprint.pformat(state))
+
+airsim.wait_key('Press any key to takeoff')
+client.takeoffAsync().join()
+
+airsim.wait_key('Press any key to land')
+client.landAsync().join()
+
+client.enableApiControl(False)

--- a/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/FixedWingPawn.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/FixedWingPawn.cpp
@@ -1,0 +1,5 @@
+#include "FixedWingPawn.h"
+
+AFixedWingPawn::AFixedWingPawn()
+{
+}

--- a/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/FixedWingPawn.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/FixedWingPawn.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "vehicles/fixedwing/api/FixedWingApiBase.hpp"
+#include "PawnSimApi.h"
+#include "GameFramework/Pawn.h"
+#include "FixedWingPawn.generated.h"
+
+UCLASS()
+class AIRSIM_API AFixedWingPawn : public APawn
+{
+    GENERATED_BODY()
+
+public:
+    AFixedWingPawn();
+};
+

--- a/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/SimModeFixedWing.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/SimModeFixedWing.cpp
@@ -1,0 +1,12 @@
+#include "SimModeFixedWing.h"
+#include "common/AirSimSettings.hpp"
+
+void ASimModeFixedWing::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+bool ASimModeFixedWing::isVehicleTypeSupported(const std::string& vehicle_type) const
+{
+    return vehicle_type == AirSimSettings::kVehicleTypeFixedWing;
+}

--- a/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/SimModeFixedWing.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/SimModeFixedWing.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "SimMode/SimModeBase.h"
+#include "FixedWingPawn.h"
+#include "SimModeFixedWing.generated.h"
+
+UCLASS()
+class AIRSIM_API ASimModeFixedWing : public ASimModeBase
+{
+    GENERATED_BODY()
+public:
+    virtual void BeginPlay() override;
+protected:
+    virtual bool isVehicleTypeSupported(const std::string& vehicle_type) const override;
+};

--- a/cmake/AirLib/CMakeLists.txt
+++ b/cmake/AirLib/CMakeLists.txt
@@ -21,6 +21,7 @@ file(GLOB_RECURSE ${PROJECT_NAME}_sources
   ${AIRSIM_ROOT}/${PROJECT_NAME}/src/vehicles/car/api/*.cpp
   ${AIRSIM_ROOT}/${PROJECT_NAME}/src/vehicles/multirotor/*.cpp
   ${AIRSIM_ROOT}/${PROJECT_NAME}/src/vehicles/multirotor/api/*.cpp
+  ${AIRSIM_ROOT}/${PROJECT_NAME}/src/vehicles/fixedwing/api/*.cpp
 )
 
 add_library(${PROJECT_NAME} STATIC ${${PROJECT_NAME}_sources})

--- a/settings_fixedwing.json
+++ b/settings_fixedwing.json
@@ -1,0 +1,25 @@
+{
+  "SettingsVersion": 1.2,
+  "SimMode": "FixedWing",
+  "Vehicles": {
+    "FixedWing1": {
+      "VehicleType": "FixedWing",
+      "AutoCreate": true,
+      "Cameras": {
+        "front_center": {
+          "CaptureSettings": [
+            {"ImageType": 0, "Width": 640, "Height": 480, "FOV_Degrees": 90},
+            {"ImageType": 7, "Width": 640, "Height": 480, "FOV_Degrees": 90}
+          ]
+        }
+      },
+      "Sensors": {
+        "Imu": {"SensorType": 2, "Enabled": true},
+        "Barometer": {"SensorType": 1, "Enabled": true},
+        "Gps": {"SensorType": 3, "Enabled": true},
+        "Magnetometer": {"SensorType": 4, "Enabled": true}
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- create `FixedWingApiBase` and RPC client/server stubs
- add FixedWing pawn and sim mode classes
- expose `FixedWingClient` in Python API and sample `hello_fixed_wing.py`
- register fixed wing sources in CMake and new vehicle type constant
- sample settings file showing infrared and normal cameras

## Testing
- `python -m py_compile PythonClient/fixedwing/hello_fixed_wing.py`
- `python -m py_compile PythonClient/airsim/client.py`


------
https://chatgpt.com/codex/tasks/task_e_684551cfa35883249972b48e02a06d29