### PR TITLE
Add FixedWing API with stabilization loop

### DIFF
--- a/AirLib/include/vehicles/fixedwing/FixedWingApiFactory.hpp
+++ b/AirLib/include/vehicles/fixedwing/FixedWingApiFactory.hpp
@@ -2,6 +2,7 @@
 #define msr_airlib_vehicles_FixedWingApiFactory_hpp
 
 #include "FixedWingApiBase.hpp"
+#include "vehicles/fixedwing/api/FixedWingApi.hpp"
 
 namespace msr {
 namespace airlib {
@@ -13,7 +14,7 @@ public:
                                                        std::shared_ptr<SensorFactory> sensor_factory,
                                                        const Kinematics::State& state, const Environment& environment)
     {
-        return std::unique_ptr<FixedWingApiBase>(new FixedWingApiBase(vehicle_setting, sensor_factory, state, environment));
+        return std::unique_ptr<FixedWingApiBase>(new FixedWingApi(vehicle_setting, sensor_factory, state, environment));
     }
 };
 

--- a/AirLib/include/vehicles/fixedwing/api/FixedWingApi.hpp
+++ b/AirLib/include/vehicles/fixedwing/api/FixedWingApi.hpp
@@ -1,0 +1,44 @@
+#ifndef msr_AirLib_FixedWingApi_hpp
+#define msr_AirLib_FixedWingApi_hpp
+
+#include "vehicles/fixedwing/api/FixedWingApiBase.hpp"
+#include "common/PidController.hpp"
+#include "physics/PhysicsBody.hpp"
+
+namespace msr {
+namespace airlib {
+
+class FixedWingApi : public FixedWingApiBase
+{
+public:
+    struct ControlSurfaces
+    {
+        float pitch = 0; // desired pitch angle in radians
+        float roll = 0;  // desired roll angle in radians
+        float yaw = 0;   // desired yaw angle in radians
+        float throttle = 0; // desired forward speed
+    };
+
+public:
+    FixedWingApi(const AirSimSettings::VehicleSetting* vehicle_setting,
+                 std::shared_ptr<SensorFactory> sensor_factory,
+                 const Kinematics::State& state, const Environment& environment);
+
+    virtual void update() override;
+
+    void setControlSurfaces(const ControlSurfaces& controls);
+    ControlSurfaces getControlSurfaces() const;
+
+protected:
+    ControlSurfaces target_controls_;
+    ControlSurfaces current_controls_;
+
+    PidController pitch_pid_;
+    PidController roll_pid_;
+    PidController yaw_pid_;
+    PidController throttle_pid_;
+};
+
+}} //namespace
+
+#endif

--- a/AirLib/include/vehicles/fixedwing/api/FixedWingRpcLibAdaptors.hpp
+++ b/AirLib/include/vehicles/fixedwing/api/FixedWingRpcLibAdaptors.hpp
@@ -1,0 +1,47 @@
+#ifndef msr_AirLib_FixedWingRpcLibAdaptors_hpp
+#define msr_AirLib_FixedWingRpcLibAdaptors_hpp
+
+#include "api/RpcLibAdaptorsBase.hpp"
+#include "vehicles/fixedwing/api/FixedWingApi.hpp"
+#include "common/common_utils/WindowsApisCommonPre.hpp"
+#include "rpc/msgpack.hpp"
+#include "common/common_utils/WindowsApisCommonPost.hpp"
+
+namespace msr {
+namespace airlib_rpclib {
+
+class FixedWingRpcLibAdaptors : public RpcLibAdaptorsBase
+{
+public:
+    struct ControlSurfaces
+    {
+        float pitch = 0;
+        float roll = 0;
+        float yaw = 0;
+        float throttle = 0;
+
+        MSGPACK_DEFINE_ARRAY(pitch, roll, yaw, throttle);
+
+        ControlSurfaces() {}
+        ControlSurfaces(const msr::airlib::FixedWingApi::ControlSurfaces& s)
+        {
+            pitch = s.pitch;
+            roll = s.roll;
+            yaw = s.yaw;
+            throttle = s.throttle;
+        }
+        msr::airlib::FixedWingApi::ControlSurfaces to() const
+        {
+            msr::airlib::FixedWingApi::ControlSurfaces s;
+            s.pitch = pitch;
+            s.roll = roll;
+            s.yaw = yaw;
+            s.throttle = throttle;
+            return s;
+        }
+    };
+};
+
+}} //namespace
+
+#endif

--- a/AirLib/include/vehicles/fixedwing/api/FixedWingRpcLibClient.hpp
+++ b/AirLib/include/vehicles/fixedwing/api/FixedWingRpcLibClient.hpp
@@ -3,6 +3,8 @@
 
 #include "rpc/client.h"
 #include "vehicles/multirotor/api/MultirotorRpcLibClient.hpp"
+#include "vehicles/fixedwing/api/FixedWingApi.hpp"
+#include "vehicles/fixedwing/api/FixedWingRpcLibAdaptors.hpp"
 
 namespace msr {
 namespace airlib {
@@ -14,6 +16,9 @@ public:
         : MultirotorRpcLibClient(ip, port, timeout_sec)
     {
     }
+
+    void setControlSurfaces(const FixedWingApi::ControlSurfaces& controls, const std::string& vehicle_name="");
+    FixedWingApi::ControlSurfaces getControlSurfaces(const std::string& vehicle_name="");
 };
 
 }} //namespace

--- a/AirLib/include/vehicles/fixedwing/api/FixedWingRpcLibServer.hpp
+++ b/AirLib/include/vehicles/fixedwing/api/FixedWingRpcLibServer.hpp
@@ -2,6 +2,8 @@
 #define msr_AirLib_FixedWingRpcLibServer_hpp
 
 #include "vehicles/multirotor/api/MultirotorRpcLibServer.hpp"
+#include "vehicles/fixedwing/api/FixedWingApi.hpp"
+#include "vehicles/fixedwing/api/FixedWingRpcLibAdaptors.hpp"
 
 namespace msr {
 namespace airlib {
@@ -12,6 +14,12 @@ public:
     FixedWingRpcLibServer(ApiProvider* api_provider, const string& ip_address="", uint16_t port=41451)
         : MultirotorRpcLibServer(api_provider, ip_address, port)
     {
+    }
+
+protected:
+    virtual FixedWingApi* getVehicleApi(const std::string& vehicle_name) override
+    {
+        return static_cast<FixedWingApi*>(RpcLibServerBase::getVehicleApi(vehicle_name));
     }
 };
 

--- a/AirLib/src/vehicles/fixedwing/api/FixedWingApi.cpp
+++ b/AirLib/src/vehicles/fixedwing/api/FixedWingApi.cpp
@@ -1,0 +1,54 @@
+#include "vehicles/fixedwing/api/FixedWingApi.hpp"
+#include "common/VectorMath.hpp"
+
+using namespace msr::airlib;
+
+FixedWingApi::FixedWingApi(const AirSimSettings::VehicleSetting* vehicle_setting,
+                           std::shared_ptr<SensorFactory> sensor_factory,
+                           const Kinematics::State& state, const Environment& environment)
+    : FixedWingApiBase(vehicle_setting, sensor_factory, state, environment)
+{
+    pitch_pid_.setPoint(0, 0.5f, 0.0f, 0.05f);
+    roll_pid_.setPoint(0, 0.5f, 0.0f, 0.05f);
+    yaw_pid_.setPoint(0, 0.5f, 0.0f, 0.05f);
+    throttle_pid_.setPoint(0, 1.0f, 0.0f, 0.0f);
+}
+
+void FixedWingApi::setControlSurfaces(const ControlSurfaces& controls)
+{
+    target_controls_ = controls;
+    pitch_pid_.setPoint(controls.pitch, 0.5f, 0.0f, 0.05f);
+    roll_pid_.setPoint(controls.roll, 0.5f, 0.0f, 0.05f);
+    yaw_pid_.setPoint(controls.yaw, 0.5f, 0.0f, 0.05f);
+    throttle_pid_.setPoint(controls.throttle, 1.0f, 0.0f, 0.0f);
+}
+
+FixedWingApi::ControlSurfaces FixedWingApi::getControlSurfaces() const
+{
+    return current_controls_;
+}
+
+void FixedWingApi::update()
+{
+    FixedWingApiBase::update();
+
+    auto* body = static_cast<PhysicsBody*>(getParent());
+    if (body == nullptr)
+        return;
+
+    const auto& kin = body->getKinematics();
+    float pitch, roll, yaw;
+    VectorMath::toEulerianAngle(kin.pose.orientation, pitch, roll, yaw);
+    Vector3r vel_body = VectorMath::transformToBodyFrame(kin.twist.linear, kin.pose.orientation);
+
+    current_controls_.pitch = pitch_pid_.control(pitch);
+    current_controls_.roll = roll_pid_.control(roll);
+    current_controls_.yaw = yaw_pid_.control(yaw);
+    current_controls_.throttle = throttle_pid_.control(vel_body.x());
+
+    Wrench wrench = body->getWrench();
+    wrench.torque += Vector3r(current_controls_.roll, current_controls_.pitch, current_controls_.yaw);
+    wrench.force += VectorMath::transformToWorldFrame(Vector3r(current_controls_.throttle, 0, 0), kin.pose.orientation);
+    body->setWrench(wrench);
+}
+

--- a/AirLib/src/vehicles/fixedwing/api/FixedWingRpcLibClient.cpp
+++ b/AirLib/src/vehicles/fixedwing/api/FixedWingRpcLibClient.cpp
@@ -1,8 +1,19 @@
 #include "vehicles/fixedwing/api/FixedWingRpcLibClient.hpp"
+#include "vehicles/fixedwing/api/FixedWingRpcLibAdaptors.hpp"
 
 using namespace msr::airlib;
 
 FixedWingRpcLibClient::FixedWingRpcLibClient(const std::string& ip, uint16_t port, float timeout_sec)
     : MultirotorRpcLibClient(ip, port, timeout_sec)
 {
+}
+
+void FixedWingRpcLibClient::setControlSurfaces(const FixedWingApi::ControlSurfaces& controls, const std::string& vehicle_name)
+{
+    static_cast<rpc::client*>(getClient())->call("setControlSurfaces", airlib_rpclib::FixedWingRpcLibAdaptors::ControlSurfaces(controls), vehicle_name);
+}
+
+FixedWingApi::ControlSurfaces FixedWingRpcLibClient::getControlSurfaces(const std::string& vehicle_name)
+{
+    return static_cast<rpc::client*>(getClient())->call("getControlSurfaces", vehicle_name).as<airlib_rpclib::FixedWingRpcLibAdaptors::ControlSurfaces>().to();
 }

--- a/AirLib/src/vehicles/fixedwing/api/FixedWingRpcLibServer.cpp
+++ b/AirLib/src/vehicles/fixedwing/api/FixedWingRpcLibServer.cpp
@@ -1,8 +1,18 @@
 #include "vehicles/fixedwing/api/FixedWingRpcLibServer.hpp"
+#include "vehicles/fixedwing/api/FixedWingRpcLibAdaptors.hpp"
+#include "rpc/server.h"
 
 using namespace msr::airlib;
+
+using namespace msr::airlib_rpclib;
 
 FixedWingRpcLibServer::FixedWingRpcLibServer(ApiProvider* api_provider, const string& ip_address, uint16_t port)
     : MultirotorRpcLibServer(api_provider, ip_address, port)
 {
+    (static_cast<rpc::server*>(getServer()))->bind("setControlSurfaces", [&](const FixedWingRpcLibAdaptors::ControlSurfaces& c, const std::string& vehicle_name) -> void {
+        getVehicleApi(vehicle_name)->setControlSurfaces(c.to());
+    });
+    (static_cast<rpc::server*>(getServer()))->bind("getControlSurfaces", [&](const std::string& vehicle_name) -> FixedWingRpcLibAdaptors::ControlSurfaces {
+        return FixedWingRpcLibAdaptors::ControlSurfaces(getVehicleApi(vehicle_name)->getControlSurfaces());
+    });
 }

--- a/PythonClient/airsim/client.py
+++ b/PythonClient/airsim/client.py
@@ -1658,3 +1658,10 @@ class FixedWingClient(VehicleClient, object):
 
     def landAsync(self, timeout_sec = 60, vehicle_name = ''):
         return self.client.call_async('land', timeout_sec, vehicle_name)
+
+    def setControlSurfaces(self, controls, vehicle_name=''):
+        self.client.call('setControlSurfaces', controls, vehicle_name)
+
+    def getControlSurfaces(self, vehicle_name=''):
+        raw = self.client.call('getControlSurfaces', vehicle_name)
+        return FixedWingControls.from_msgpack(raw)

--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -503,7 +503,27 @@ class CarControls(MsgpackMixin):
         else:
             self.is_manual_gear = False
             self.manual_gear = -1
-            self.throttle = - abs(throttle_val)
+        self.throttle = - abs(throttle_val)
+
+
+class FixedWingControls(MsgpackMixin):
+    pitch = 0.0
+    roll = 0.0
+    yaw = 0.0
+    throttle = 0.0
+
+    attribute_order = [
+        ('pitch', float),
+        ('roll', float),
+        ('yaw', float),
+        ('throttle', float)
+    ]
+
+    def __init__(self, pitch=0, roll=0, yaw=0, throttle=0):
+        self.pitch = pitch
+        self.roll = roll
+        self.yaw = yaw
+        self.throttle = throttle
 
 
 class KinematicsState(MsgpackMixin):


### PR DESCRIPTION
## Summary
- implement `FixedWingApi` with PID based stabilization
- expose control surfaces RPC methods and Python wrappers
- generate FixedWing RPC adaptors and server/client bindings

## Testing
- `python3 -m py_compile PythonClient/airsim/client.py PythonClient/airsim/types.py`
- `./build.sh` *(fails: requires rpclib setup)*

------
https://chatgpt.com/codex/tasks/task_e_6846853687648324a8fe08b24aba7374