### PR TITLE
Add fixed wing pawn simulation API

### DIFF
--- a/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/FixedWingPawn.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/FixedWingPawn.cpp
@@ -1,5 +1,43 @@
 #include "FixedWingPawn.h"
+#include "AirBlueprintLib.h"
+#include "Components/ChildActorComponent.h"
 
 AFixedWingPawn::AFixedWingPawn()
 {
+    camera_front_center_ = nullptr;
 }
+
+void AFixedWingPawn::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+void AFixedWingPawn::initializeForBeginPlay()
+{
+    camera_front_center_ = Cast<APIPCamera>(
+        (UAirBlueprintLib::GetActorComponent<UChildActorComponent>(this, TEXT("FrontCenterCamera")))->GetChildActor());
+}
+
+const common_utils::UniqueValueMap<std::string, APIPCamera*> AFixedWingPawn::getCameras() const
+{
+    common_utils::UniqueValueMap<std::string, APIPCamera*> cameras;
+    cameras.insert_or_assign("front_center", camera_front_center_);
+    cameras.insert_or_assign("0", camera_front_center_);
+    cameras.insert_or_assign("fpv", camera_front_center_);
+    cameras.insert_or_assign("", camera_front_center_);
+    return cameras;
+}
+
+void AFixedWingPawn::Tick(float DeltaSeconds)
+{
+    Super::Tick(DeltaSeconds);
+    pawn_events_.getPawnTickSignal().emit(DeltaSeconds);
+}
+
+void AFixedWingPawn::NotifyHit(class UPrimitiveComponent* MyComp, class AActor* Other, class UPrimitiveComponent* OtherComp,
+                               bool bSelfMoved, FVector HitLocation, FVector HitNormal, FVector NormalImpulse,
+                               const FHitResult& Hit)
+{
+    pawn_events_.getCollisionSignal().emit(MyComp, Other, OtherComp, bSelfMoved, HitLocation, HitNormal, NormalImpulse, Hit);
+}
+

--- a/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/FixedWingPawn.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/FixedWingPawn.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include "vehicles/fixedwing/api/FixedWingApiBase.hpp"
+#include "PawnEvents.h"
 #include "PawnSimApi.h"
+#include "PIPCamera.h"
 #include "GameFramework/Pawn.h"
+#include "common/common_utils/UniqueValueMap.hpp"
 #include "FixedWingPawn.generated.h"
 
 UCLASS()
@@ -12,5 +15,21 @@ class AIRSIM_API AFixedWingPawn : public APawn
 
 public:
     AFixedWingPawn();
+
+    virtual void BeginPlay() override;
+    virtual void Tick(float DeltaSeconds) override;
+    virtual void NotifyHit(class UPrimitiveComponent* MyComp, class AActor* Other, class UPrimitiveComponent* OtherComp,
+                           bool bSelfMoved, FVector HitLocation, FVector HitNormal, FVector NormalImpulse,
+                           const FHitResult& Hit) override;
+
+    void initializeForBeginPlay();
+    const common_utils::UniqueValueMap<std::string, APIPCamera*> getCameras() const;
+    PawnEvents* getPawnEvents() { return &pawn_events_; }
+
+private:
+    UPROPERTY()
+    APIPCamera* camera_front_center_;
+
+    PawnEvents pawn_events_;
 };
 

--- a/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/FixedWingPawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/FixedWingPawnSimApi.cpp
@@ -1,0 +1,80 @@
+#include "FixedWingPawnSimApi.h"
+#include "AirBlueprintLib.h"
+#include "UnrealSensors/UnrealSensorFactory.h"
+#include <exception>
+
+using namespace msr::airlib;
+
+FixedWingPawnSimApi::FixedWingPawnSimApi(const Params& params)
+    : PawnSimApi(params)
+{
+}
+
+void FixedWingPawnSimApi::initialize()
+{
+    PawnSimApi::initialize();
+
+    std::shared_ptr<UnrealSensorFactory> sensor_factory = std::make_shared<UnrealSensorFactory>(getPawn(), &getNedTransform());
+    vehicle_params_ = FixedWingParamsFactory::createConfig(getVehicleSetting());
+    auto api_base = FixedWingApiFactory::createApi(getVehicleSetting(), sensor_factory, *getGroundTruthKinematics(), *getGroundTruthEnvironment());
+    vehicle_api_.reset(static_cast<FixedWingApi*>(api_base.release()));
+
+    physics_body_ = std::unique_ptr<FixedWingPhysicsBody>(new FixedWingPhysicsBody(vehicle_params_.get(), vehicle_api_.get(), getKinematics(), getEnvironment()));
+
+    vehicle_api_->setSimulatedGroundTruth(getGroundTruthKinematics(), getGroundTruthEnvironment());
+
+    last_phys_pose_ = Pose::nanPose();
+}
+
+void FixedWingPawnSimApi::updateRenderedState(float dt)
+{
+    PawnSimApi::updateRenderedState(dt);
+
+    const CollisionInfo& collision_info = getCollisionInfo();
+    physics_body_->setCollisionInfo(collision_info);
+
+    last_phys_pose_ = physics_body_->getPose();
+}
+
+void FixedWingPawnSimApi::updateRendering(float dt)
+{
+    PawnSimApi::updateRendering(dt);
+
+    if (!VectorMath::hasNan(last_phys_pose_))
+        PawnSimApi::setPose(last_phys_pose_, false);
+
+    try {
+        vehicle_api_->sendTelemetry(dt);
+    }
+    catch (std::exception& e) {
+        UAirBlueprintLib::LogMessage(FString(e.what()), TEXT(""), LogDebugLevel::Failure, 30);
+    }
+}
+
+void FixedWingPawnSimApi::resetImplementation()
+{
+    PawnSimApi::resetImplementation();
+
+    vehicle_api_->reset();
+    physics_body_->reset();
+}
+
+void FixedWingPawnSimApi::update()
+{
+    PawnSimApi::update();
+
+    physics_body_->update();
+}
+
+void FixedWingPawnSimApi::reportState(StateReporter& reporter)
+{
+    PawnSimApi::reportState(reporter);
+
+    physics_body_->reportState(reporter);
+}
+
+FixedWingPawnSimApi::UpdatableObject* FixedWingPawnSimApi::getPhysicsBody()
+{
+    return physics_body_->getPhysicsBody();
+}
+

--- a/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/FixedWingPawnSimApi.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/FixedWingPawnSimApi.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "PawnSimApi.h"
+#include "vehicles/fixedwing/FixedWingPhysicsBody.hpp"
+#include "vehicles/fixedwing/FixedWingParams.hpp"
+#include "vehicles/fixedwing/FixedWingApiFactory.hpp"
+#include "vehicles/fixedwing/api/FixedWingApi.hpp"
+
+class FixedWingPawnSimApi : public PawnSimApi
+{
+public:
+    typedef msr::airlib::Utils Utils;
+    typedef msr::airlib::StateReporter StateReporter;
+    typedef msr::airlib::UpdatableObject UpdatableObject;
+    typedef msr::airlib::Pose Pose;
+
+public:
+    FixedWingPawnSimApi(const Params& params);
+    virtual void initialize() override;
+    virtual ~FixedWingPawnSimApi() = default;
+
+    virtual void updateRenderedState(float dt) override;
+    virtual void updateRendering(float dt) override;
+
+    virtual void resetImplementation() override;
+    virtual void update() override;
+    virtual void reportState(StateReporter& reporter) override;
+    virtual UpdatableObject* getPhysicsBody() override;
+
+    msr::airlib::FixedWingApi* getVehicleApi() const { return vehicle_api_.get(); }
+    virtual msr::airlib::VehicleApiBase* getVehicleApiBase() const override { return vehicle_api_.get(); }
+
+private:
+    std::unique_ptr<msr::airlib::FixedWingApi> vehicle_api_;
+    std::unique_ptr<msr::airlib::FixedWingParams> vehicle_params_;
+    std::unique_ptr<msr::airlib::FixedWingPhysicsBody> physics_body_;
+
+    msr::airlib::Pose last_phys_pose_;
+};
+

--- a/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/SimModeFixedWing.cpp
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/SimModeFixedWing.cpp
@@ -1,12 +1,71 @@
 #include "SimModeFixedWing.h"
+#include "UObject/ConstructorHelpers.h"
+#include "Engine/World.h"
+#include "AirBlueprintLib.h"
 #include "common/AirSimSettings.hpp"
+#include "FixedWingPawnSimApi.h"
+#include "vehicles/fixedwing/api/FixedWingRpcLibServer.hpp"
 
 void ASimModeFixedWing::BeginPlay()
 {
     Super::BeginPlay();
 }
 
+std::unique_ptr<msr::airlib::ApiServerBase> ASimModeFixedWing::createApiServer() const
+{
+#ifdef AIRLIB_NO_RPC
+    return ASimModeBase::createApiServer();
+#else
+    return std::unique_ptr<msr::airlib::ApiServerBase>(new msr::airlib::FixedWingRpcLibServer(
+        getApiProvider(), getSettings().api_server_address, getSettings().api_port));
+#endif
+}
+
+void ASimModeFixedWing::getExistingVehiclePawns(TArray<AActor*>& pawns) const
+{
+    UAirBlueprintLib::FindAllActor<AFixedWingPawn>(this, pawns);
+}
+
 bool ASimModeFixedWing::isVehicleTypeSupported(const std::string& vehicle_type) const
 {
     return vehicle_type == AirSimSettings::kVehicleTypeFixedWing;
 }
+
+std::string ASimModeFixedWing::getVehiclePawnPathName(const AirSimSettings::VehicleSetting& vehicle_setting) const
+{
+    std::string pawn_path = vehicle_setting.pawn_path;
+    if (pawn_path == "")
+        pawn_path = "DefaultFixedWing";
+    return pawn_path;
+}
+
+PawnEvents* ASimModeFixedWing::getVehiclePawnEvents(APawn* pawn) const
+{
+    return static_cast<AFixedWingPawn*>(pawn)->getPawnEvents();
+}
+
+const common_utils::UniqueValueMap<std::string, APIPCamera*> ASimModeFixedWing::getVehiclePawnCameras(APawn* pawn) const
+{
+    return static_cast<const AFixedWingPawn*>(pawn)->getCameras();
+}
+
+void ASimModeFixedWing::initializeVehiclePawn(APawn* pawn)
+{
+    static_cast<AFixedWingPawn*>(pawn)->initializeForBeginPlay();
+}
+
+std::unique_ptr<PawnSimApi> ASimModeFixedWing::createVehicleSimApi(const PawnSimApi::Params& pawn_sim_api_params) const
+{
+    auto vehicle_sim_api = std::unique_ptr<PawnSimApi>(new FixedWingPawnSimApi(pawn_sim_api_params));
+    vehicle_sim_api->initialize();
+    vehicle_sim_api->reset();
+    return vehicle_sim_api;
+}
+
+msr::airlib::VehicleApiBase* ASimModeFixedWing::getVehicleApi(const PawnSimApi::Params& pawn_sim_api_params,
+                                                              const PawnSimApi* sim_api) const
+{
+    const auto fixed_sim_api = static_cast<const FixedWingPawnSimApi*>(sim_api);
+    return fixed_sim_api->getVehicleApi();
+}
+

--- a/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/SimModeFixedWing.h
+++ b/Unreal/Plugins/AirSim/Source/Vehicles/FixedWing/SimModeFixedWing.h
@@ -10,6 +10,17 @@ class AIRSIM_API ASimModeFixedWing : public ASimModeBase
     GENERATED_BODY()
 public:
     virtual void BeginPlay() override;
+
 protected:
+    virtual std::unique_ptr<msr::airlib::ApiServerBase> createApiServer() const override;
+    virtual void getExistingVehiclePawns(TArray<AActor*>& pawns) const override;
     virtual bool isVehicleTypeSupported(const std::string& vehicle_type) const override;
+    virtual std::string getVehiclePawnPathName(const AirSimSettings::VehicleSetting& vehicle_setting) const override;
+    virtual PawnEvents* getVehiclePawnEvents(APawn* pawn) const override;
+    virtual const common_utils::UniqueValueMap<std::string, APIPCamera*> getVehiclePawnCameras(APawn* pawn) const override;
+    virtual void initializeVehiclePawn(APawn* pawn) override;
+    virtual std::unique_ptr<PawnSimApi> createVehicleSimApi(const PawnSimApi::Params& pawn_sim_api_params) const override;
+    virtual msr::airlib::VehicleApiBase* getVehicleApi(const PawnSimApi::Params& pawn_sim_api_params,
+                                                       const PawnSimApi* sim_api) const override;
 };
+


### PR DESCRIPTION
## Summary
- implement `FixedWingPawnSimApi` with physics integration
- add pawn events and camera accessors for `AFixedWingPawn`
- extend `SimModeFixedWing` to create and manage fixed wing vehicles

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684687562b908324bb83612e8097a192