### PR TITLE
Add FixedWing docs and sample

### DIFF
--- a/PythonClient/fixedwing/hello_fixed_wing.py
+++ b/PythonClient/fixedwing/hello_fixed_wing.py
@@ -1,6 +1,8 @@
 import setup_path
 import airsim
 import pprint
+import os
+import tempfile
 
 client = airsim.FixedWingClient()
 client.confirmConnection()
@@ -11,6 +13,22 @@ print("state: %s" % pprint.pformat(state))
 
 airsim.wait_key('Press any key to takeoff')
 client.takeoffAsync().join()
+
+airsim.wait_key('Press any key to control surfaces and capture image')
+client.setControlSurfaces(airsim.FixedWingControls(pitch=-0.2, throttle=0.6))
+print('Controls:', client.getControlSurfaces())
+
+responses = client.simGetImages([
+    airsim.ImageRequest("0", airsim.ImageType.Scene),
+    airsim.ImageRequest("0", airsim.ImageType.DepthVis)
+])
+tmp_dir = os.path.join(tempfile.gettempdir(), "airsim_fixedwing")
+os.makedirs(tmp_dir, exist_ok=True)
+for idx, response in enumerate(responses):
+    if response.pixels_as_float:
+        airsim.write_pfm(os.path.join(tmp_dir, f"{idx}.pfm"), airsim.get_pfm_array(response))
+    else:
+        airsim.write_file(os.path.join(tmp_dir, f"{idx}.png"), response.image_data_uint8)
 
 airsim.wait_key('Press any key to land')
 client.landAsync().join()

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -114,6 +114,30 @@ for response in responses:
         airsim.write_file(os.path.normpath('/temp/py1.png'), response.image_data_uint8)
 ```
 
+## Hello Fixed Wing
+Here's how to use Colosseum APIs using Python to control a fixed wing vehicle:
+
+```python
+# ready to run example: PythonClient/fixedwing/hello_fixed_wing.py
+import airsim
+
+# connect to the Colosseum simulator
+client = airsim.FixedWingClient()
+client.confirmConnection()
+client.enableApiControl(True)
+client.takeoffAsync().join()
+
+# set small pitch angle and throttle
+client.setControlSurfaces(airsim.FixedWingControls(pitch=-0.2, throttle=0.6))
+
+# capture images
+responses = client.simGetImages([
+    airsim.ImageRequest("0", airsim.ImageType.Scene),
+    airsim.ImageRequest("0", airsim.ImageType.DepthVis)
+])
+print('Retrieved images:', len(responses))
+```
+
 ## Common APIs
 
 * `reset`: This resets the vehicle to its original starting state. Note that you must call `enableApiControl` and `armDisarm` again after the call to `reset`.
@@ -279,6 +303,13 @@ In most cases, you just don't want yaw to change which you can do by setting yaw
 
 #### lookahead and adaptive_lookahead
 When you ask vehicle to follow a path, Colosseum uses "carrot following" algorithm. This algorithm operates by looking ahead on path and adjusting its velocity vector. The parameters for this algorithm is specified by `lookahead` and `adaptive_lookahead`. For most of the time you want algorithm to auto-decide the values by simply setting `lookahead = -1` and `adaptive_lookahead = 0`.
+
+### APIs for Fixed Wing
+Fixed wing vehicles can be controlled by directly specifying control surface values.
+
+* `setControlSurfaces`: set pitch, roll, yaw and throttle.
+* `getControlSurfaces`: retrieve current control surface values.
+* `takeoffAsync` and `landAsync` are available similar to multirotors.
 
 ## Using APIs on Real Vehicles
 We want to be able to run *same code* that runs in simulation as on real vehicle. This allows you to test your code in simulator and deploy to real vehicle.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -215,6 +215,7 @@ SimMode determines which simulation mode will be used. Below are currently suppo
 - `"Multirotor"`: Use multirotor simulation
 - `"Car"`: Use car simulation
 - `"ComputerVision"`: Use only camera, no vehicle or physics
+- `"FixedWing"`: Use fixed wing simulation
 
 ## ViewMode
 The ViewMode determines which camera to use as default and how camera will follow the vehicle. For multirotors, the default ViewMode is `"FlyWithMe"` while for cars the default ViewMode is `"SpringArmChase"`.
@@ -367,7 +368,7 @@ This element allows specifying cameras which are separate from the cameras attac
 Each simulation mode will go through the list of vehicles specified in this setting and create the ones that has `"AutoCreate": true`. Each vehicle specified in this setting has key which becomes the name of the vehicle. If `"Vehicles"` element is missing then this list is populated with default car named "PhysXCar" and default multirotor named "SimpleFlight".
 
 ### Common Vehicle Setting
-- `VehicleType`: This could be any one of the following - `PhysXCar`, `SimpleFlight`, `PX4Multirotor`, `ComputerVision`, `ArduCopter` & `ArduRover`. There is no default value therefore this element must be specified.
+- `VehicleType`: This could be any one of the following - `PhysXCar`, `SimpleFlight`, `PX4Multirotor`, `ComputerVision`, `ArduCopter`, `ArduRover` & `FixedWing`. There is no default value therefore this element must be specified.
 - `PawnPath`: This allows to override the pawn blueprint to use for the vehicle. For example, you may create new pawn blueprint derived from ACarPawn for a warehouse robot in your own project outside the Colosseum code and then specify its path here. See also [PawnPaths](settings.md#PawnPaths). Note that you have to specify your custom pawn blueprint class path inside the global `PawnPaths` object using your proprietarily defined object name, and quote that name inside the `Vehicles` setting. For example,
 ```json
     {
@@ -499,6 +500,23 @@ PX4 connection. See [Setting up PX4 Software-in-Loop](px4_sitl.md) for an exampl
 ### Using ArduPilot
 
 [ArduPilot](https://ardupilot.org/) Copter & Rover vehicles are supported in latest Colosseum main branch & releases `v1.3.0` and later. For settings and how to use, please see [ArduPilot SITL with Colosseum](https://ardupilot.org/dev/docs/sitl-with-airsim.html)
+
+### Using FixedWing
+
+Below is a minimal example for a fixed wing configuration:
+
+```json
+{
+  "SettingsVersion": 1.2,
+  "SimMode": "FixedWing",
+  "Vehicles": {
+    "FixedWing1": {
+      "VehicleType": "FixedWing",
+      "AutoCreate": true
+    }
+  }
+}
+```
 
 ## Other Settings
 


### PR DESCRIPTION
## Summary
- document FixedWing sim mode and vehicle settings
- show how to control FixedWing from Python
- add APIs for Fixed Wing in docs

## Testing
- `python3 -m py_compile PythonClient/fixedwing/hello_fixed_wing.py`

------
https://chatgpt.com/codex/tasks/task_e_68468a7d1cb883248333878777a8c3e4